### PR TITLE
support Chinese namespace

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -71,7 +71,7 @@ class syntax_plugin_pagenav extends DokuWiki_Syntax_Plugin {
         if(is_null($list)){
             $list = array();
             $ns = str_replace(':','/',getNS($INFO['id']));
-            search($list,$conf['datadir'],'search_list',array(),$ns);
+            search($list,$conf['datadir'],'search_list',array(),urlencode($ns));
         }
         $id = $INFO['id'];
 


### PR DESCRIPTION
When using Chinese namespaces. Browser will encode them(eg.  %E4%B8%AD%E6%96%87%E7%9A%84). And DokuWiki will create folder with the new string.  But page nav will not recognize it.