### PR TITLE
Don't add hidden pages to navigation

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -86,6 +86,7 @@ class syntax_plugin_pagenav extends DokuWiki_Syntax_Plugin
             } else {
                 if ($glob && !preg_match('/' . $glob . '/', noNS($list[$i]['id']))) continue;
                 if ($list[$i]['id'] == $start) continue;
+                if (isHiddenPage($list[$i]['id'])) continue;
 
                 if ($self) {
                     // we're after the current id


### PR DESCRIPTION
Hidden pages are still being shown in the navigation bar. So the sidebar appears sometime when navigating between the pages.

With this lookup for the "hidden" property of each page in the NS, the behavior is as proposed in the wiki page of the plugin ("You should also make sure the sidebar is set up to be hidden through the hidepages option.")